### PR TITLE
Read Readme.md as utf-8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 import setuptools
 
-with open("README.md", "r") as fh:
+with open("README.md", "r", encoding="utf8") as fh:
     long_description = fh.read()
 
 setuptools.setup(


### PR DESCRIPTION
Fix Windows ```'charmap' codec can't decode byte``` Error